### PR TITLE
Allow 'auth_require' to take an array.

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -62,15 +62,19 @@
     Require <%= req %>
         <%- end -%>
       <%- end -%>
-      <%- if directory['auth_require'] -%>
+      <%- if directory['auth_require'] && directory['auth_require'] != '' -%>
+        <%- Array(directory['auth_require']).each do |auth_req| -%>
     Require <%= directory['auth_require'] %>
+        <%- end -%>
       <%- end -%>
       <%- if !(directory['require'] && directory['require'] != '') && directory['require'] !~ /unmanaged/i && !(directory['auth_require']) -%>
     Require all granted
       <%- end -%>
     <%- else -%>
-      <%- if directory['auth_require'] -%>
+      <%- if directory['auth_require'] && directory['auth_require'] != '' -%>
+        <%- Array(directory['auth_require']).each do |auth_req| -%>
     Require <%= directory['auth_require'] %>
+        <%- end -%>
       <%- end -%>
       <%- if directory['order'] and directory['order'] != '' -%>
     Order <%= Array(directory['order']).join(',') %>


### PR DESCRIPTION
This will allow stanzas like this:

  <LocationMatch "CONDITION">
    Require user user1
    Require group group1
  </LocationMatch>

In addition, if auth_require is set to an empty string, it should not be inserted. This is a valid case because the require directives may be already defined in a parent location.
